### PR TITLE
fix: remove sqlite3 from requirements.txt

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,4 +3,3 @@ uvicorn[standard]==0.24.0
 python-multipart==0.0.6
 python-dotenv==1.0.0
 slowapi==0.1.8
-sqlite3


### PR DESCRIPTION
sqlite3 is part of Python's standard library and cannot be installed via pip.
Removing it from requirements.txt prevents installation errors.